### PR TITLE
fixed freq_low

### DIFF
--- a/apps/scanner.py
+++ b/apps/scanner.py
@@ -495,7 +495,7 @@ class Scanner(object):
         self.min_freq = (self.center_freq - self.samp_rate/2)
         self.max_freq = (self.center_freq + self.samp_rate/2)
         # reset low/high freq for demod based on new center and bounds from original provided
-        self.freq_low = self.low_bound - self.center_freq
+        self.freq_low = self.low_bound + self.center_freq
         self.freq_high = self.high_bound + self.center_freq
         # cannot set channel freq lower than min sampled freq
         if (self.freq_low < self.min_freq):


### PR DESCRIPTION
Before this change the gui showed wrong value for Low Tune.  It always showed as Min Freq no matter what range was chosen.  With this change the gui shows the correct value.  I tested with:

- range on one side of center freq
- range on other side of center freq
- ranges that straddled the center freq
- ranges that were outside the bounds of the rate

I am specifying range like `-e 460000000-460200000`.

This is my first time working with this fork so if I am missing something (likely) please let me know.
